### PR TITLE
use WebResourceHandler interface for multipart uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@balena/lint": "^9.1.3",
-    "@balena/pinejs": "^21.0.0",
+    "@balena/pinejs": "^21.3.0",
     "@balena/sbvr-types": "^9.1.0",
     "@types/chai": "^5.0.1",
     "@types/chai-as-promised": "^8.0.1",
@@ -42,7 +42,7 @@
     "memoizee": "^0.4.17"
   },
   "peerDependencies": {
-    "@balena/pinejs": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
+    "@balena/pinejs": "^21.3.0"
   },
   "versionist": {
     "publishedAt": "2025-05-06T17:33:37.130Z"


### PR DESCRIPTION
This is a major because the previous webresource handler was implementing some out of spec (non pinejs yet compliant) multi part handlers - These were experimental and should never have existed in first place, however, because they existed I am marking this as a major so that if anyone from other projects (non-balena) relied on it 

See: https://balena.fibery.io/search/vyloj#Work/Improvement/Add-multipart-upload-interface-for-webresource-handlers-and-add-them-to-S3-Cloudfront-handlers-2584

Change-type: major