### PR TITLE
Stop relying on customer fillable content to create s3 keys

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -101,7 +101,7 @@ export class S3Handler implements webResourceHandler.WebResourceHandler {
 		resource: webResourceHandler.IncomingFile,
 	): Promise<webResourceHandler.UploadResponse> {
 		let size = 0;
-		const key = this.getFileKey(resource.fieldname, resource.originalname);
+		const key = this.getFileKey(resource.fieldname);
 		const params: PutObjectCommandInput = {
 			Bucket: this.bucket,
 			Key: key,
@@ -154,7 +154,7 @@ export class S3Handler implements webResourceHandler.WebResourceHandler {
 		fieldName: string,
 		payload: BeginMultipartUploadPayload,
 	): Promise<BeginMultipartUploadHandlerResponse> {
-		const fileKey = this.getFileKey(fieldName, payload.filename);
+		const fileKey = this.getFileKey(fieldName);
 
 		const createMultiPartResponse = await this.client.send(
 			new CreateMultipartUploadCommand({
@@ -225,8 +225,8 @@ export class S3Handler implements webResourceHandler.WebResourceHandler {
 		return hrefWithoutParams.substring(hrefWithoutParams.lastIndexOf('/') + 1);
 	}
 
-	private getFileKey(fieldName: string, fileName: string) {
-		return `${fieldName}_${randomUUID()}_${fileName}`;
+	private getFileKey(fieldName: string) {
+		return `${fieldName}_${randomUUID()}`;
 	}
 
 	private async getUploadParts(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -107,6 +107,7 @@ export class S3Handler implements webResourceHandler.WebResourceHandler {
 			Key: key,
 			Body: resource.stream,
 			ContentType: resource.mimetype,
+			ContentDisposition: `inline; filename=${resource.originalname}`,
 		};
 		const upload = new Upload({ client: this.client, params });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -182,7 +182,7 @@ describe('S3Handler', function () {
 					'text/plain',
 				);
 				expect(s3Mock.calls()[0].firstArg.input.Key).to.match(
-					new RegExp(`test_[0-9a-f-]+_${payload.filename}`),
+					new RegExp(`test_[0-9a-f-]+`),
 				);
 			};
 		}
@@ -270,7 +270,7 @@ describe('S3Handler', function () {
 				'text/plain',
 			);
 			expect(s3Mock.calls()[0].firstArg.input.Key).to.match(
-				new RegExp(`test_[0-9a-f-]+_${payload.filename}`),
+				new RegExp(`test_[0-9a-f-]+`),
 			);
 		});
 	});


### PR DESCRIPTION
Using the filename on the s3 key is not a good idea as these can contain lots of weird characters and open ways for security breaches. The UUID should be enough to guarantee uniqueness on the keys and the fieldName should be enough to at least point to a direction on what this resource is.

This is also not breaking as the href field of old webresources should still work fine but the new ones shall not use possibly skewed data.

See: https://balena.fibery.io/search/DMBt7#Work/Improvement/Make-webresources-file-deletion-more-reliable-2819

Change-type: patch